### PR TITLE
Compatibility with replay the Spire

### DIFF
--- a/src/main/java/chronoMods/coop/CoopEmptyRoom.java
+++ b/src/main/java/chronoMods/coop/CoopEmptyRoom.java
@@ -42,10 +42,13 @@ public class CoopEmptyRoom extends AbstractRoom {
             if (node.getRoom() instanceof MonsterRoomBoss) {
             	return SpireReturn.Return(false);
             }
-
-            if (AbstractDungeon.getCurrMapNode().getRoom() instanceof MonsterRoomBoss) {
-            	return SpireReturn.Return(false);
-            }
+	    if (AbstractDungeon.getCurrMapNode()!=null)
+	    {
+		if (AbstractDungeon.getCurrMapNode().getRoom() instanceof MonsterRoomBoss) {
+            	    return SpireReturn.Return(false);
+            	}
+	    }
+            
 
             return SpireReturn.Continue();
         }


### PR DESCRIPTION
see #33 .
This fixes the issue by checking whether you actually are in a room before checking adjacency. This should make the null pointer exception not occur.