### PR TITLE
Downfall gremlins

### DIFF
--- a/src/main/java/chronoMods/coop/relics/StringOfFate.java
+++ b/src/main/java/chronoMods/coop/relics/StringOfFate.java
@@ -66,6 +66,7 @@ public class StringOfFate extends AbstractBlight {
     public void effect() {
         if (counter > 0) {
             flash();
+            AbstractDungeon.player.isDead = false;
             AbstractDungeon.player.heal(AbstractDungeon.player.maxHealth, true);
         }
 
@@ -107,14 +108,15 @@ public class StringOfFate extends AbstractBlight {
     // This patch prevents death
     @SpirePatch(clz = AbstractPlayer.class, method="damage")
     public static class RevivePlayer {
-        @SpireInsertPatch(rloc=1874-1725, localvars={})
+        @SpireInsertPatch(rloc=1875-1725, localvars={})
         public static SpireReturn Insert(AbstractPlayer player, DamageInfo info) {
-
-            if (player.hasBlight("StringOfFate")) {
-                player.currentHealth = 0;
-                player.getBlight("StringOfFate").effect();
-                return SpireReturn.Return(null);
-            } 
+            if (player.isDead) {
+                if (player.hasBlight("StringOfFate")) {
+                    player.currentHealth = 0;
+                    player.getBlight("StringOfFate").effect();
+                    return SpireReturn.Return(null);
+                } 
+            }
 
             return SpireReturn.Continue();
         }


### PR DESCRIPTION
Some info about Gremlins from downfall:
Gremlins is a character which is in fact many characters. You can change the active gremlin, Revive a gremlin at campfire and many things.

This might be only a partial solution, but what it does is this:
Before PR:
When any gremlin dies, a life is lost. If it's the last, it revives.
After PR:
When the last gremlin dies, a life is lost. If it's the last, it revives.

This should help people use strategies where its preferable to use less gremlins, or just not to be a burden to the team